### PR TITLE
fix: DatabaseControllerのエラーを修正 - GetConnectionString()メソッドの問題を解決

### DIFF
--- a/backend/ShopifyTestApi/Controllers/DatabaseController.cs
+++ b/backend/ShopifyTestApi/Controllers/DatabaseController.cs
@@ -5,6 +5,7 @@ using ShopifyTestApi.Data;
 using ShopifyTestApi.Models;
 using ShopifyTestApi.Services;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 
 namespace ShopifyTestApi.Controllers
 {
@@ -36,13 +37,24 @@ namespace ShopifyTestApi.Controllers
             try
             {
                 var canConnect = await _context.Database.CanConnectAsync();
-                var connectionString = _context.Database.GetConnectionString();
+                
+                // 接続文字列を安全に取得
+                string connectionStringPreview = "";
+                try
+                {
+                    var connection = _context.Database.GetDbConnection();
+                    connectionStringPreview = connection.ConnectionString?.Substring(0, Math.Min(50, connection.ConnectionString.Length)) + "...";
+                }
+                catch
+                {
+                    connectionStringPreview = "接続文字列の取得に失敗";
+                }
 
                 return Ok(new
                 {
                     success = canConnect,
                     message = canConnect ? "データベース接続成功" : "データベース接続失敗",
-                    connectionString = connectionString?.Substring(0, Math.Min(50, connectionString.Length)) + "...",
+                    connectionString = connectionStringPreview,
                     timestamp = DateTime.UtcNow
                 });
             }


### PR DESCRIPTION
## 問題
- DatabaseControllerの`/test`エンドポイントで500エラーが発生
- `GetConnectionString()`メソッドが存在しないためエラーが発生
- バックエンドアプリケーションは起動しているが、APIエンドポイントが動作しない

## 修正内容

### バックエンド (backend/ShopifyTestApi/Controllers/DatabaseController.cs)
- **GetConnectionString()の修正**: `GetDbConnection().ConnectionString`に変更
- **エラーハンドリング強化**: 接続文字列取得時の例外処理を追加
- **using文の追加**: `Microsoft.Data.SqlClient`を追加

## 技術的詳細
- Entity Framework Coreでは`GetConnectionString()`メソッドが存在しない
- `GetDbConnection().ConnectionString`で正しく接続文字列を取得
- 例外処理により、接続文字列取得に失敗してもAPIが動作する

## テスト結果
- [x] バックエンドアプリケーション起動確認
- [x] データベース接続テスト
- [x] APIエンドポイントの動作確認

## 影響範囲
- DatabaseControllerの`/test`エンドポイントが正常に動作
- フロントエンド・バックエンド連携の復旧
- CORS問題の解決

Closes: DatabaseControllerエラー
Related: #database-integration