### PR TITLE
fix: DatabaseControllerのDI依存関係を修正 - IDatabaseServiceインターフェースを使用

### DIFF
--- a/backend/ShopifyTestApi/Controllers/DatabaseController.cs
+++ b/backend/ShopifyTestApi/Controllers/DatabaseController.cs
@@ -15,12 +15,12 @@ namespace ShopifyTestApi.Controllers
     public class DatabaseController : ControllerBase
     {
         private readonly ShopifyDbContext _context;
-        private readonly DatabaseService _databaseService;
+        private readonly IDatabaseService _databaseService;
         private readonly ILogger<DatabaseController> _logger;
 
         public DatabaseController(
             ShopifyDbContext context,
-            DatabaseService databaseService,
+            IDatabaseService databaseService,
             ILogger<DatabaseController> logger)
         {
             _context = context;


### PR DESCRIPTION
## 問題
- DatabaseControllerでDatabaseServiceを直接使用していたが、DIコンテナにはIDatabaseServiceとして登録されている
- ローカル環境でDIエラーが発生: `Unable to resolve service for type 'ShopifyTestApi.Services.DatabaseService'`
- バックエンドアプリケーションは起動するが、APIエンドポイントでエラーが発生

## 修正内容

### バックエンド (backend/ShopifyTestApi/Controllers/DatabaseController.cs)
- **依存関係の修正**: `DatabaseService`から`IDatabaseService`に変更
- **コンストラクタの修正**: インターフェースを使用するように修正
- **DIコンテナとの整合性**: 正しい依存関係の注入を実現

## 技術的詳細
- DIコンテナには`IDatabaseService`として登録されている
- コンストラクタでは`DatabaseService`を直接使用していた
- インターフェースを使用することで依存関係の逆転を実現

## テスト結果
- [x] ローカル環境でのDIエラー解決
- [x] バックエンドアプリケーション起動確認
- [x] APIエンドポイントの動作確認

## 影響範囲
- DatabaseControllerの正常動作を確保
- フロントエンド・バックエンド連携の復旧
- CORS問題の解決

Closes: DI依存関係エラー
Related: #database-integration