### PR TITLE
security: CORS設定を環境別に分離し、セキュリティを強化

### DIFF
--- a/backend/ShopifyTestApi/appsettings.json
+++ b/backend/ShopifyTestApi/appsettings.json
@@ -2,6 +2,13 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=tcp:shopify-test-server.database.windows.net,1433;Initial Catalog=shopify-test-db;Persist Security Info=False;User ID=sqladmin;Password=ShopifyTest2025!;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "https://brave-sea-038f17a00.1.azurestaticapps.net",
+      "https://localhost:3000",
+      "http://localhost:3000"
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## 問題
- 本番環境で`AllowAnyOrigin()`を使用しており、セキュリティリスクが高い
- 開発環境と本番環境で同じCORS設定を使用していた
- 一時的な解決策から本格的なセキュリティ設定への移行が必要

## 修正内容

### バックエンド (backend/ShopifyTestApi/Program.cs)
- **環境別CORS設定**: 開発環境と本番環境で異なる設定を実装
- **開発環境**: `AllowAnyOrigin()`で柔軟な開発環境を維持
- **本番環境**: 特定のオリジンのみ許可する厳格な設定
- **設定ファイル統合**: `appsettings.json`からCORS設定を読み込み

### 設定ファイル (backend/ShopifyTestApi/appsettings.json)
- **CORS設定セクション**: `AllowedOrigins`配列を追加
- **許可するオリジン**: フロントエンドの本番URLとローカル開発URLを指定
- **フォールバック機能**: 設定ファイルが読み込めない場合のデフォルト設定

## 技術的詳細

### 開発環境
```csharp
policy.AllowAnyOrigin()
      .AllowAnyMethod()
      .AllowAnyHeader();
```

### 本番環境
```csharp
policy.WithOrigins(corsOrigins)
      .AllowAnyMethod()
      .AllowAnyHeader()
      .AllowCredentials();
```

## セキュリティ改善

### 変更前（リスク）
- すべてのオリジンからのアクセスを許可
- 本番環境でも緩い設定
- セキュリティリスクが高い

### 変更後（安全）
- 特定のオリジンのみ許可
- 環境別の適切な設定
- 設定ファイルでの管理

## 影響範囲
- **セキュリティ向上**: 本番環境での不正アクセスを防止
- **開発効率維持**: 開発環境では柔軟な設定を継続
- **保守性向上**: 設定ファイルでの管理により変更が容易

## 設定可能なオリジン
- `https://brave-sea-038f17a00.1.azurestaticapps.net` (フロントエンド本番)
- `https://localhost:3000` (ローカル開発)
- `http://localhost:3000` (ローカル開発)

## テスト結果
- [x] 開発環境での動作確認
- [x] 本番環境での動作確認
- [x] CORS設定の正常動作
- [x] フロントエンド・バックエンド連携

Closes: CORSセキュリティ強化
Related: #security #cors-configuration