### PR TITLE
feat: 休眠顧客API統合とルートページリダイレクト変更

### DIFF
--- a/docs/BOOKMARKS.md
+++ b/docs/BOOKMARKS.md
@@ -1,6 +1,33 @@
 # 🔖 Shopify AIマーケティングスイート - ブックマークリンク集
 
-## 📅 最終更新: 2025年7月23日 [[memory:3773065]]
+## 📅 最終更新: 2025年7月24日 [[memory:3773065]]
+
+---
+
+## 🎯 **各機能への直リンク集（開発環境）**
+
+### **📦 商品分析機能**
+- [📊 **売上ダッシュボード【概要】**](https://brave-sea-038f17a00.1.azurestaticapps.net/sales/dashboard) - 売上の全体像と主要KPIをリアルタイム確認
+- [📈 **前年同月比較【商品別】**](https://brave-sea-038f17a00.1.azurestaticapps.net/sales/year-over-year) - 商品別の売上トレンドを前年と詳細比較
+- [🔄 **リピート購入分析【商品】**](https://brave-sea-038f17a00.1.azurestaticapps.net/sales/purchase-frequency) - 商品別のリピート購入パターンと頻度分析
+- [🛒 **バスケット分析【商品】**](https://brave-sea-038f17a00.1.azurestaticapps.net/sales/market-basket) - 一緒に購入される商品の組み合わせとトレンド分析
+
+### **🛍️ 購買分析機能**
+- [📅 **月次売上レポート【購買】**](https://brave-sea-038f17a00.1.azurestaticapps.net/sales/monthly-stats) - 商品別×月別の売上推移を数量・金額で詳細把握
+- [🔢 **購入回数セグメント【購買】**](https://brave-sea-038f17a00.1.azurestaticapps.net/purchase/frequency-detail) - 顧客の購入回数別セグメント分析と前年比較レポート
+- [📊 **顧客階層トレンド【購買】**](https://brave-sea-038f17a00.1.azurestaticapps.net/purchase/f-tier-trend) - 購入頻度による顧客階層の時系列変化とトレンド分析
+
+### **👥 顧客分析機能**
+- [👤 **顧客プロファイル【顧客】**](https://brave-sea-038f17a00.1.azurestaticapps.net/customers/profile) - 顧客別の詳細な購買履歴とプロファイル分析
+- [😴 **休眠顧客マネジメント【顧客】**](https://brave-sea-038f17a00.1.azurestaticapps.net/customers/dormant) - 最終購入からの経過期間別顧客分類と復帰施策管理
+
+### **🤖 AIインサイト機能**
+- [🤖 **AIインサイト**](https://brave-sea-038f17a00.1.azurestaticapps.net/ai-insights) - AI予測・提案機能
+
+### **🧪 テスト・開発機能**
+- [🧪 **API接続テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/api-test) - Shopify API動作確認
+- [🗄️ **Database API テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/database-test) - Azure SQL統合確認
+- [🔍 **休眠顧客API テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/dormant-api-test) - 休眠顧客分析API専用テスト画面 ✅ **NEW!**
 
 ---
 
@@ -10,6 +37,7 @@
 - [🏠 **メインサイト**](https://brave-sea-038f17a00.1.azurestaticapps.net) - 開発環境フロントエンド
 - [🧪 **API接続テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/api-test) - Shopify API動作確認
 - [🗄️ **Database API テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/database-test) - Azure SQL統合確認 ✅ **新機能**
+- [🔍 **休眠顧客API テスト**](https://brave-sea-038f17a00.1.azurestaticapps.net/dormant-api-test) - 休眠顧客分析API専用テスト画面 ✅ **NEW!**
 
 ### **🔌 バックエンドAPI (開発環境)**
 - [❤️ **Health Check**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/health) - API稼働確認
@@ -20,6 +48,8 @@
 - [🔍 **Customer Test**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/customer/test) - Shopify接続テスト
 - [👥 **Customer Segments**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/customer/segments) - 顧客セグメント
 - [📊 **Customer Dashboard**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/customer/dashboard) - ダッシュボードデータ
+- [😴 **Dormant Customers**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/customer/dormant) - 休眠顧客分析API ✅ **NEW!**
+- [📋 **Dormant Summary**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/customer/dormant/summary) - 休眠顧客サマリー統計 ✅ **NEW!**
 - [📄 **Swagger API仕様**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/swagger) - API仕様書
 - [🔍 **Health Ready Check**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/health/ready) - 詳細ヘルスチェック ✅ **新機能**
 - [ℹ️ **Environment Info**](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/env-info) - 環境情報確認 ✅ **新機能**
@@ -64,6 +94,7 @@ URL: 未定（後日決定）
 ### **🖥️ 開発サーバー**
 - [🎨 **フロントエンド**](http://localhost:3000) - Next.js開発サーバー
 - [🗄️ **Database API テスト (ローカル)**](http://localhost:3000/database-test) - ローカルDB統合テスト
+- [🔍 **休眠顧客API テスト (ローカル)**](http://localhost:3000/dormant-api-test) - ローカル休眠顧客分析テスト ✅ **NEW!**
 - [⚡ **バックエンドAPI**](https://localhost:7177) - ASP.NET Core API
 - [📖 **Swagger (ローカル)**](https://localhost:7177/swagger) - ローカルAPI仕様
 - [🧪 **API接続テスト (ローカル)**](http://localhost:3000/api-test) - ローカルShopifyテスト
@@ -75,6 +106,8 @@ URL: 未定（後日決定）
 - [🔌 **Local Database Test**](https://localhost:7177/api/database/test) - ローカルDB接続テスト
 - [👥 **Local Database Customers**](https://localhost:7177/api/database/customers) - ローカル顧客データ
 - [🔍 **Local Customer Test**](https://localhost:7177/api/customer/test) - ローカルShopify接続テスト
+- [😴 **Local Dormant Customers**](https://localhost:7177/api/customer/dormant) - ローカル休眠顧客分析API ✅ **NEW!**
+- [📋 **Local Dormant Summary**](https://localhost:7177/api/customer/dormant/summary) - ローカル休眠顧客サマリー ✅ **NEW!**
 
 ---
 
@@ -109,6 +142,7 @@ URL: 未定（後日決定）
 |------|----------|----------|
 | サイト表示 | [🌐 開発サイト](https://brave-sea-038f17a00.1.azurestaticapps.net) | [🖥️ ローカル](http://localhost:3000) |
 | Database API | [🗄️ DB統合テスト](https://brave-sea-038f17a00.1.azurestaticapps.net/database-test) | [🗄️ ローカルDBテスト](http://localhost:3000/database-test) |
+| 休眠顧客API | [🔍 休眠顧客テスト](https://brave-sea-038f17a00.1.azurestaticapps.net/dormant-api-test) | [🔍 ローカル休眠テスト](http://localhost:3000/dormant-api-test) |
 | API動作 | [❤️ Health Check](https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net/api/health) | [❤️ Local Health](https://localhost:7177/api/health) |
 | Shopify連携 | [🧪 API接続テスト](https://brave-sea-038f17a00.1.azurestaticapps.net/api-test) | [🧪 ローカルテスト](http://localhost:3000/api-test) |
 
@@ -168,6 +202,7 @@ URL: 未定（後日決定）
 - ✅ developブランチ戦略導入 (2025-07-20) ⭐ **最新成果**
 - ✅ 包括的ログシステム実装 (2025-07-23) ⭐ **最新成果**
 - ✅ Application Insights統合 (2025-07-23) ⭐ **最新成果**
+- ✅ 休眠顧客API専用テスト画面作成 (2025-07-24) ⭐ **最新成果**
 
 ### **🔄 Phase 2 開発中**
 - 🔄 feature ブランチでの機能開発開始予定

--- a/frontend/src/app/customers/dormant/page.tsx
+++ b/frontend/src/app/customers/dormant/page.tsx
@@ -2,28 +2,149 @@
 
 import { useMemo } from "react"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 
 // 統一された休眠顧客分析コンポーネント
 import DormantCustomerAnalysis from "@/components/dashboards/DormantCustomerAnalysis"
 import { AnalyticsHeaderUnified } from "@/components/layout/AnalyticsHeaderUnified"
 
-import { dormantCustomerDetails } from "@/data/mock/customerData"
+import { api } from "@/lib/api-client"
+import { API_CONFIG } from "@/lib/api-config"
 import { useDormantFilters } from "@/contexts/FilterContext"
+import { useState, useEffect } from "react"
 
 export default function DormantCustomersPage() {
   // ✅ Props Drilling解消: フィルター状態は FilterContext で管理
   const { filters } = useDormantFilters()
+  
+  // API データ管理
+  const [dormantData, setDormantData] = useState<any[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // API からデータを取得
+  useEffect(() => {
+    const fetchDormantData = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        
+        console.log('🔄 休眠顧客データの取得を開始...')
+        
+        const response = await api.dormantCustomers({
+          storeId: 1,
+          pageSize: 1000, // 全件取得してフィルタリング
+          sortBy: 'DaysSinceLastPurchase',
+          descending: true
+        })
+        
+        console.log('✅ APIレスポンス取得成功:', response)
+        setDormantData(response.data || [])
+        
+      } catch (err) {
+        console.error('❌ 休眠顧客データの取得に失敗:', err)
+        
+        // より詳細なエラー情報を構築
+        let errorMessage = 'データの取得に失敗しました'
+        let errorDetails = ''
+        
+        if (err instanceof Error) {
+          errorMessage = err.message
+          errorDetails = err.stack || ''
+        } else if (typeof err === 'string') {
+          errorMessage = err
+        } else if (err && typeof err === 'object') {
+          errorMessage = JSON.stringify(err)
+        }
+        
+        console.error('📋 エラー詳細:', {
+          message: errorMessage,
+          details: errorDetails,
+          type: typeof err,
+          constructor: err?.constructor?.name
+        })
+        
+        setError(`${errorMessage}\n\n詳細: ${errorDetails}`)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchDormantData()
+  }, [])
 
   // フィルタリングされた顧客データ（表示用）- useMemoで最適化
   const filteredCustomers = useMemo(() => {
+    if (!dormantData) return []
+    
     const selectedSegment = filters.selectedSegment
     return selectedSegment 
-      ? dormantCustomerDetails.filter(customer => {
-          const daysSince = customer.dormancy.daysSincePurchase
+      ? dormantData.filter(customer => {
+          const daysSince = customer.daysSinceLastPurchase || customer.dormancy?.daysSincePurchase || 0
           return daysSince >= selectedSegment.range[0] && daysSince < selectedSegment.range[1]
         })
-      : dormantCustomerDetails
-  }, [filters.selectedSegment])
+      : dormantData
+  }, [dormantData, filters.selectedSegment])
+
+  // ローディング状態
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+            <p className="mt-4 text-gray-600">休眠顧客データを読み込み中...</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // エラー状態
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center max-w-2xl">
+            <div className="text-red-500 text-lg mb-4">❌ データの取得に失敗しました</div>
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+              <pre className="text-sm text-red-700 whitespace-pre-wrap overflow-auto max-h-40">
+                {error}
+              </pre>
+            </div>
+            <div className="text-sm text-gray-600 mb-4">
+              <p>💡 トラブルシューティング:</p>
+              <ul className="list-disc list-inside mt-2 space-y-1">
+                <li>ブラウザの開発者ツールでネットワークタブを確認</li>
+                <li>コンソールタブでエラーログを確認</li>
+                <li>APIサーバーが正常に動作しているか確認</li>
+              </ul>
+            </div>
+            <div className="space-x-4">
+              <Button 
+                onClick={() => window.location.reload()} 
+                variant="outline"
+              >
+                再読み込み
+              </Button>
+              <Button 
+                onClick={() => {
+                  console.log('🔍 デバッグ情報:');
+                  console.log('  - Current URL:', window.location.href);
+                  console.log('  - User Agent:', navigator.userAgent);
+                  console.log('  - API Config:', { API_CONFIG });
+                }} 
+                variant="secondary"
+                size="sm"
+              >
+                デバッグ情報
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -39,7 +160,8 @@ export default function DormantCustomersPage() {
         badges={[
           { label: `${filteredCustomers.length}名`, variant: "outline" as const },
           { label: "復帰施策", variant: "secondary" as const },
-          { label: "期間セグメント", variant: "default" as const }
+          { label: "期間セグメント", variant: "default" as const },
+          { label: "🔗 API連携", variant: "default" as const }
         ]}
       />
 

--- a/frontend/src/app/dev-bookmarks/page.tsx
+++ b/frontend/src/app/dev-bookmarks/page.tsx
@@ -1,0 +1,420 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { 
+  BarChart3, 
+  TrendingUp, 
+  ShoppingCart, 
+  Users, 
+  Brain,
+  Settings,
+  Database,
+  TestTube,
+  Activity,
+  Target,
+  Calendar,
+  Package,
+  ShoppingBag,
+  UserCheck,
+  UserX,
+  Zap
+} from "lucide-react"
+import Link from "next/link"
+
+interface BookmarkItem {
+  title: string
+  description: string
+  href: string
+  icon: React.ReactNode
+  status: 'implemented' | 'in-progress' | 'planned'
+  category: 'sales' | 'purchase' | 'customer' | 'ai' | 'dev'
+}
+
+const bookmarkItems: BookmarkItem[] = [
+  // 売上分析
+  {
+    title: "売上ダッシュボード",
+    description: "売上・商品の統合分析ダッシュボード",
+    href: "/sales/dashboard",
+    icon: <BarChart3 className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'sales'
+  },
+  {
+    title: "前年同月比【商品】",
+    description: "商品別の前年同月比較分析",
+    href: "/sales/year-over-year",
+    icon: <TrendingUp className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'sales'
+  },
+  {
+    title: "購入頻度【商品】",
+    description: "商品の購入頻度分析",
+    href: "/purchase/frequency-detail",
+    icon: <ShoppingCart className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'sales'
+  },
+  {
+    title: "組み合わせ商品【商品】",
+    description: "商品の組み合わせ分析",
+    href: "/sales/market-basket",
+    icon: <Package className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'sales'
+  },
+  {
+    title: "月別売上統計【購買】",
+    description: "月別の売上統計分析",
+    href: "/sales/monthly-stats",
+    icon: <Calendar className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'sales'
+  },
+
+  // 購買分析
+  {
+    title: "購入回数【購買】",
+    description: "顧客の購入回数分析",
+    href: "/purchase/purchase-frequency",
+    icon: <ShoppingBag className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'purchase'
+  },
+  {
+    title: "F階層傾向【購買】",
+    description: "購買頻度階層の傾向分析",
+    href: "/purchase/f-tier-trend",
+    icon: <Target className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'purchase'
+  },
+
+  // 顧客分析
+  {
+    title: "顧客ダッシュボード",
+    description: "顧客セグメント統合分析",
+    href: "/customers/dashboard",
+    icon: <Users className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'customer'
+  },
+  {
+    title: "顧客購買【顧客】",
+    description: "顧客の購買行動分析",
+    href: "/customers/profile",
+    icon: <UserCheck className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'customer'
+  },
+  {
+    title: "休眠顧客【顧客】",
+    description: "休眠顧客の分析と復帰施策",
+    href: "/customers/dormant",
+    icon: <UserX className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'customer'
+  },
+
+  // AI分析
+  {
+    title: "AIインサイト",
+    description: "AI予測・提案システム",
+    href: "/ai-insights",
+    icon: <Brain className="h-5 w-5" />,
+    status: 'planned',
+    category: 'ai'
+  },
+
+  // 開発・テスト用
+  {
+    title: "API テスト",
+    description: "API接続テスト画面",
+    href: "/api-test",
+    icon: <TestTube className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'dev'
+  },
+  {
+    title: "休眠顧客API テスト",
+    description: "休眠顧客APIの動作確認",
+    href: "/dormant-api-test",
+    icon: <Activity className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'dev'
+  },
+  {
+    title: "データベース テスト",
+    description: "データベース接続テスト",
+    href: "/database-test",
+    icon: <Database className="h-5 w-5" />,
+    status: 'implemented',
+    category: 'dev'
+  }
+]
+
+const getStatusBadge = (status: BookmarkItem['status']) => {
+  switch (status) {
+    case 'implemented':
+      return <Badge variant="default" className="bg-green-100 text-green-800">実装済み</Badge>
+    case 'in-progress':
+      return <Badge variant="secondary" className="bg-yellow-100 text-yellow-800">開発中</Badge>
+    case 'planned':
+      return <Badge variant="outline" className="bg-gray-100 text-gray-800">実装予定</Badge>
+  }
+}
+
+const getCategoryColor = (category: BookmarkItem['category']) => {
+  switch (category) {
+    case 'sales':
+      return 'bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200'
+    case 'purchase':
+      return 'bg-gradient-to-br from-green-50 to-green-100 border-green-200'
+    case 'customer':
+      return 'bg-gradient-to-br from-purple-50 to-purple-100 border-purple-200'
+    case 'ai':
+      return 'bg-gradient-to-br from-amber-50 to-amber-100 border-amber-200'
+    case 'dev':
+      return 'bg-gradient-to-br from-gray-50 to-gray-100 border-gray-200'
+  }
+}
+
+export default function DevBookmarksPage() {
+  return (
+    <div className="space-y-6">
+      {/* ヘッダー */}
+      <div className="text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          🔖 開発用ブックマーク
+        </h1>
+        <p className="text-gray-600">
+          各機能への直接アクセス用ページ
+        </p>
+        <div className="mt-4 flex justify-center gap-2">
+          <Badge variant="outline">開発効率向上</Badge>
+          <Badge variant="outline">クイックアクセス</Badge>
+          <Badge variant="outline">機能確認</Badge>
+        </div>
+      </div>
+
+      {/* カテゴリ別ブックマーク */}
+      <div className="space-y-8">
+        {/* 売上分析 */}
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-blue-600" />
+            売上分析
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {bookmarkItems
+              .filter(item => item.category === 'sales')
+              .map((item, index) => (
+                <Card key={index} className={getCategoryColor(item.category)}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {item.icon}
+                        <CardTitle className="text-base">{item.title}</CardTitle>
+                      </div>
+                      {getStatusBadge(item.status)}
+                    </div>
+                    <CardDescription className="text-sm">
+                      {item.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Link href={item.href}>
+                      <Button variant="outline" size="sm" className="w-full">
+                        アクセス
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+          </div>
+        </div>
+
+        {/* 購買分析 */}
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <ShoppingCart className="h-5 w-5 text-green-600" />
+            購買分析
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {bookmarkItems
+              .filter(item => item.category === 'purchase')
+              .map((item, index) => (
+                <Card key={index} className={getCategoryColor(item.category)}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {item.icon}
+                        <CardTitle className="text-base">{item.title}</CardTitle>
+                      </div>
+                      {getStatusBadge(item.status)}
+                    </div>
+                    <CardDescription className="text-sm">
+                      {item.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Link href={item.href}>
+                      <Button variant="outline" size="sm" className="w-full">
+                        アクセス
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+          </div>
+        </div>
+
+        {/* 顧客分析 */}
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <Users className="h-5 w-5 text-purple-600" />
+            顧客分析
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {bookmarkItems
+              .filter(item => item.category === 'customer')
+              .map((item, index) => (
+                <Card key={index} className={getCategoryColor(item.category)}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {item.icon}
+                        <CardTitle className="text-base">{item.title}</CardTitle>
+                      </div>
+                      {getStatusBadge(item.status)}
+                    </div>
+                    <CardDescription className="text-sm">
+                      {item.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Link href={item.href}>
+                      <Button variant="outline" size="sm" className="w-full">
+                        アクセス
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+          </div>
+        </div>
+
+        {/* AI分析 */}
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <Brain className="h-5 w-5 text-amber-600" />
+            AI分析
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {bookmarkItems
+              .filter(item => item.category === 'ai')
+              .map((item, index) => (
+                <Card key={index} className={getCategoryColor(item.category)}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {item.icon}
+                        <CardTitle className="text-base">{item.title}</CardTitle>
+                      </div>
+                      {getStatusBadge(item.status)}
+                    </div>
+                    <CardDescription className="text-sm">
+                      {item.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Link href={item.href}>
+                      <Button variant="outline" size="sm" className="w-full">
+                        アクセス
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+          </div>
+        </div>
+
+        {/* 開発・テスト用 */}
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <Settings className="h-5 w-5 text-gray-600" />
+            開発・テスト用
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {bookmarkItems
+              .filter(item => item.category === 'dev')
+              .map((item, index) => (
+                <Card key={index} className={getCategoryColor(item.category)}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {item.icon}
+                        <CardTitle className="text-base">{item.title}</CardTitle>
+                      </div>
+                      {getStatusBadge(item.status)}
+                    </div>
+                    <CardDescription className="text-sm">
+                      {item.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Link href={item.href}>
+                      <Button variant="outline" size="sm" className="w-full">
+                        アクセス
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 統計情報 */}
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5" />
+            機能統計
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+            <div>
+              <div className="text-2xl font-bold text-green-600">
+                {bookmarkItems.filter(item => item.status === 'implemented').length}
+              </div>
+              <div className="text-sm text-gray-600">実装済み</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-yellow-600">
+                {bookmarkItems.filter(item => item.status === 'in-progress').length}
+              </div>
+              <div className="text-sm text-gray-600">開発中</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-gray-600">
+                {bookmarkItems.filter(item => item.status === 'planned').length}
+              </div>
+              <div className="text-sm text-gray-600">実装予定</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-blue-600">
+                {bookmarkItems.length}
+              </div>
+              <div className="text-sm text-gray-600">総機能数</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+} 

--- a/frontend/src/app/dormant-api-test/page.tsx
+++ b/frontend/src/app/dormant-api-test/page.tsx
@@ -1,0 +1,11 @@
+import DormantApiTestComponent from '../../components/test/DormantApiTestComponent';
+
+export default function DormantApiTestPage() {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <div className="container mx-auto py-8">
+        <DormantApiTestComponent />
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,9 +8,9 @@ import { Badge } from "@/components/ui/badge"
 export default function HomePage() {
   const router = useRouter()
 
-  // デフォルトで売上ダッシュボードにリダイレクト
+  // デフォルトでdev-bookmarksにリダイレクト
   useEffect(() => {
-    router.push("/sales/dashboard")
+    router.push("/dev-bookmarks")
   }, [router])
 
   return (

--- a/frontend/src/components/dashboards/DormantCustomerAnalysis.tsx
+++ b/frontend/src/components/dashboards/DormantCustomerAnalysis.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -26,23 +26,155 @@ import { DormantAnalysisChart } from "@/components/dashboards/dormant/DormantAna
 import { DormantCustomerList } from "@/components/dashboards/dormant/DormantCustomerList"
 import { ReactivationInsights } from "@/components/dashboards/dormant/ReactivationInsights"
 
-import { dormantCustomerDetails } from "@/data/mock/customerData"
+import { api } from "@/lib/api-client"
 import { useDormantFilters } from "@/contexts/FilterContext"
 
 export default function DormantCustomerAnalysis() {
   const [showConditions, setShowConditions] = useState(true)
+  const [dormantData, setDormantData] = useState<any[]>([])
+  const [summaryData, setSummaryData] = useState<any>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  
   const { filters } = useDormantFilters()
+
+  // API からデータを取得
+  useEffect(() => {
+    const fetchDormantData = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        
+        console.log('🔄 休眠顧客分析データの取得を開始...')
+        
+        // 並行して両方のAPIを呼び出し
+        const [customersResponse, summaryResponse] = await Promise.all([
+          api.dormantCustomers({
+            storeId: 1,
+            pageSize: 1000, // 全件取得
+            sortBy: 'DaysSinceLastPurchase',
+            descending: true
+          }),
+          api.dormantSummary(1)
+        ])
+        
+        console.log('✅ 休眠顧客データ取得成功:', customersResponse)
+        console.log('✅ サマリーデータ取得成功:', summaryResponse)
+        
+        setDormantData(customersResponse.data || [])
+        setSummaryData(summaryResponse.data)
+        
+      } catch (err) {
+        console.error('❌ 休眠顧客分析データの取得に失敗:', err)
+        
+        // より詳細なエラー情報を構築
+        let errorMessage = 'データの取得に失敗しました'
+        let errorDetails = ''
+        
+        if (err instanceof Error) {
+          errorMessage = err.message
+          errorDetails = err.stack || ''
+        } else if (typeof err === 'string') {
+          errorMessage = err
+        } else if (err && typeof err === 'object') {
+          errorMessage = JSON.stringify(err)
+        }
+        
+        console.error('📋 エラー詳細:', {
+          message: errorMessage,
+          details: errorDetails,
+          type: typeof err,
+          constructor: err?.constructor?.name
+        })
+        
+        setError(`${errorMessage}\n\n詳細: ${errorDetails}`)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchDormantData()
+  }, [])
 
   // フィルタリングされた顧客データ
   const filteredCustomers = useMemo(() => {
+    if (!dormantData) return []
+    
     const selectedSegment = filters.selectedSegment
     return selectedSegment 
-      ? dormantCustomerDetails.filter(customer => {
-          const daysSince = customer.dormancy.daysSincePurchase
+      ? dormantData.filter(customer => {
+          const daysSince = customer.daysSinceLastPurchase || customer.dormancy?.daysSincePurchase || 0
           return daysSince >= selectedSegment.range[0] && daysSince < selectedSegment.range[1]
         })
-      : dormantCustomerDetails
-  }, [filters.selectedSegment])
+      : dormantData
+  }, [dormantData, filters.selectedSegment])
+
+  // ローディング状態
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="py-12">
+            <div className="flex items-center justify-center">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+                <p className="mt-2 text-gray-600">分析データを読み込み中...</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  // エラー状態
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="py-12">
+            <div className="flex items-center justify-center">
+              <div className="text-center max-w-2xl">
+                <div className="text-red-500 text-lg mb-4">❌ データの取得に失敗しました</div>
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+                  <pre className="text-sm text-red-700 whitespace-pre-wrap overflow-auto max-h-40">
+                    {error}
+                  </pre>
+                </div>
+                <div className="text-sm text-gray-600 mb-4">
+                  <p>💡 トラブルシューティング:</p>
+                  <ul className="list-disc list-inside mt-2 space-y-1">
+                    <li>ブラウザの開発者ツールでネットワークタブを確認</li>
+                    <li>コンソールタブでエラーログを確認</li>
+                    <li>APIサーバーが正常に動作しているか確認</li>
+                  </ul>
+                </div>
+                <div className="space-x-4">
+                  <Button 
+                    onClick={() => window.location.reload()} 
+                    variant="outline"
+                  >
+                    再読み込み
+                  </Button>
+                  <Button 
+                    onClick={() => {
+                      console.log('🔍 デバッグ情報:');
+                      console.log('  - Current URL:', window.location.href);
+                      console.log('  - User Agent:', navigator.userAgent);
+                    }} 
+                    variant="secondary"
+                    size="sm"
+                  >
+                    デバッグ情報
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -148,7 +280,10 @@ export default function DormantCustomerAnalysis() {
             </Badge>
           )}
         </h2>
-        <DormantCustomerList selectedSegment={filters.selectedSegment} />
+        <DormantCustomerList 
+          selectedSegment={filters.selectedSegment}
+          dormantData={dormantData}
+        />
       </div>
 
       {/* フッター情報 - オプション機能として一時非表示 */}

--- a/frontend/src/components/test/DormantApiTestComponent.tsx
+++ b/frontend/src/components/test/DormantApiTestComponent.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import React, { useState } from 'react';
+import { api } from '../../lib/api-client';
+
+interface TestResult {
+  endpoint: string;
+  status: 'pending' | 'success' | 'error';
+  data?: any;
+  error?: string;
+  timestamp?: string;
+  duration?: number;
+}
+
+interface DormantTestParams {
+  storeId: number;
+  segment: string;
+  riskLevel: string;
+  minTotalSpent: string;
+  maxTotalSpent: string;
+  pageNumber: number;
+  pageSize: number;
+  sortBy: string;
+  descending: boolean;
+}
+
+export default function DormantApiTestComponent() {
+  const [testResults, setTestResults] = useState<TestResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  
+  // テスト用パラメーター
+  const [params, setParams] = useState<DormantTestParams>({
+    storeId: 1,
+    segment: 'all',
+    riskLevel: '',
+    minTotalSpent: '',
+    maxTotalSpent: '',
+    pageNumber: 1,
+    pageSize: 10,
+    sortBy: 'DaysSinceLastPurchase',
+    descending: true,
+  });
+
+  const [customerId, setCustomerId] = useState<number>(1);
+
+  const updateResult = (endpoint: string, result: Partial<TestResult>) => {
+    setTestResults(prev => {
+      const existingIndex = prev.findIndex(r => r.endpoint === endpoint);
+      const newResult = { endpoint, ...result };
+      
+      if (existingIndex >= 0) {
+        const updated = [...prev];
+        updated[existingIndex] = { ...updated[existingIndex], ...newResult };
+        return updated;
+      } else {
+        return [...prev, newResult as TestResult];
+      }
+    });
+  };
+
+  const runTest = async (
+    name: string, 
+    testFn: () => Promise<any>
+  ) => {
+    const startTime = Date.now();
+    updateResult(name, { 
+      status: 'pending', 
+      timestamp: new Date().toLocaleTimeString() 
+    });
+    
+    try {
+      const response = await testFn();
+      const duration = Date.now() - startTime;
+      updateResult(name, { 
+        status: 'success', 
+        data: response.data,
+        timestamp: new Date().toLocaleTimeString(),
+        duration
+      });
+    } catch (error: any) {
+      const duration = Date.now() - startTime;
+      updateResult(name, { 
+        status: 'error', 
+        error: error.message,
+        timestamp: new Date().toLocaleTimeString(),
+        duration
+      });
+    }
+  };
+
+  // 個別テスト関数
+  const testDormantCustomers = () => {
+    const testParams: any = {
+      storeId: params.storeId,
+      pageNumber: params.pageNumber,
+      pageSize: params.pageSize,
+      sortBy: params.sortBy,
+      descending: params.descending,
+    };
+
+    // 空でない値のみ追加
+    if (params.segment && params.segment !== 'all') testParams.segment = params.segment;
+    if (params.riskLevel) testParams.riskLevel = params.riskLevel;
+    if (params.minTotalSpent) testParams.minTotalSpent = parseFloat(params.minTotalSpent);
+    if (params.maxTotalSpent) testParams.maxTotalSpent = parseFloat(params.maxTotalSpent);
+
+    return runTest('休眠顧客リスト取得', () => api.dormantCustomers(testParams));
+  };
+
+  const testDormantSummary = () => {
+    return runTest('休眠顧客サマリー取得', () => api.dormantSummary(params.storeId));
+  };
+
+  const testChurnProbability = () => {
+    return runTest(`離脱確率計算 (ID: ${customerId})`, () => api.customerChurnProbability(customerId));
+  };
+
+  const runAllTests = async () => {
+    setIsLoading(true);
+    setTestResults([]);
+    
+    try {
+      await testDormantSummary();
+      await new Promise(resolve => setTimeout(resolve, 500));
+      
+      await testDormantCustomers();
+      await new Promise(resolve => setTimeout(resolve, 500));
+      
+      await testChurnProbability();
+    } catch (error) {
+      console.error('Test suite error:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const clearResults = () => {
+    setTestResults([]);
+  };
+
+  const handleParamChange = (key: keyof DormantTestParams, value: any) => {
+    setParams(prev => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="bg-white rounded-lg shadow-lg">
+        <div className="p-6 border-b">
+          <h2 className="text-2xl font-bold text-gray-900">
+            🔍 休眠顧客分析API テスト画面
+          </h2>
+          <p className="text-gray-600 mt-2">
+            休眠顧客分析APIの動作確認とレスポンスデータの検証を行います
+          </p>
+        </div>
+        
+        <div className="p-6">
+          {/* テストパラメーター設定 */}
+          <div className="bg-gray-50 rounded-lg p-4 mb-6">
+            <h3 className="text-lg font-semibold mb-4">📋 テストパラメーター設定</h3>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {/* 基本設定 */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  ストアID
+                </label>
+                <input
+                  type="number"
+                  value={params.storeId}
+                  onChange={(e) => handleParamChange('storeId', parseInt(e.target.value))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="ストアID"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  セグメント
+                </label>
+                <select
+                  value={params.segment}
+                  onChange={(e) => handleParamChange('segment', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="セグメント"
+                >
+                  <option value="all">すべて</option>
+                  <option value="90-180日">90-180日</option>
+                  <option value="180-365日">180-365日</option>
+                  <option value="365日以上">365日以上</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  リスクレベル
+                </label>
+                <select
+                  value={params.riskLevel}
+                  onChange={(e) => handleParamChange('riskLevel', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="リスクレベル"
+                >
+                  <option value="">すべて</option>
+                  <option value="low">低</option>
+                  <option value="medium">中</option>
+                  <option value="high">高</option>
+                  <option value="critical">危険</option>
+                </select>
+              </div>
+
+              {/* ページング設定 */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  ページ番号
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={params.pageNumber}
+                  onChange={(e) => handleParamChange('pageNumber', parseInt(e.target.value))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="ページ番号"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  ページサイズ
+                </label>
+                <select
+                  value={params.pageSize}
+                  onChange={(e) => handleParamChange('pageSize', parseInt(e.target.value))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="ページサイズ"
+                >
+                  <option value={5}>5件</option>
+                  <option value={10}>10件</option>
+                  <option value={25}>25件</option>
+                  <option value={50}>50件</option>
+                </select>
+              </div>
+
+              {/* 金額フィルター */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  最小購入金額
+                </label>
+                <input
+                  type="number"
+                  value={params.minTotalSpent}
+                  onChange={(e) => handleParamChange('minTotalSpent', e.target.value)}
+                  placeholder="例: 10000"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  最大購入金額
+                </label>
+                <input
+                  type="number"
+                  value={params.maxTotalSpent}
+                  onChange={(e) => handleParamChange('maxTotalSpent', e.target.value)}
+                  placeholder="例: 100000"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              {/* 離脱確率テスト用 */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  離脱確率テスト用顧客ID
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={customerId}
+                  onChange={(e) => setCustomerId(parseInt(e.target.value))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label="離脱確率テスト用顧客ID"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* テスト実行ボタン */}
+          <div className="flex gap-4 mb-6">
+            <button
+              onClick={runAllTests}
+              disabled={isLoading}
+              className="px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+            >
+              {isLoading ? '🔄 全テスト実行中...' : '🚀 全テスト実行'}
+            </button>
+            
+            <button
+              onClick={testDormantSummary}
+              disabled={isLoading}
+              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
+            >
+              📊 サマリーのみ
+            </button>
+            
+            <button
+              onClick={testDormantCustomers}
+              disabled={isLoading}
+              className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:opacity-50"
+            >
+              👥 顧客リストのみ
+            </button>
+            
+            <button
+              onClick={testChurnProbability}
+              disabled={isLoading}
+              className="px-4 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 disabled:opacity-50"
+            >
+              📈 離脱確率のみ
+            </button>
+            
+            <button
+              onClick={clearResults}
+              className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600"
+            >
+              🗑️ 結果クリア
+            </button>
+          </div>
+
+          {/* テスト結果表示 */}
+          <div className="space-y-4">
+            {testResults.map((result, index) => (
+              <div
+                key={`${result.endpoint}-${index}`}
+                className={`p-4 rounded-lg border-l-4 ${
+                  result.status === 'success' 
+                    ? 'bg-green-50 border-green-500' 
+                    : result.status === 'error'
+                    ? 'bg-red-50 border-red-500'
+                    : 'bg-yellow-50 border-yellow-500'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-lg">
+                      {result.status === 'success' && '✅'}
+                      {result.status === 'error' && '❌'}
+                      {result.status === 'pending' && '⏳'}
+                    </span>
+                    <h3 className="font-semibold">{result.endpoint}</h3>
+                    {result.duration && (
+                      <span className="text-sm text-gray-500">
+                        ({result.duration}ms)
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-sm text-gray-500">
+                    {result.timestamp}
+                  </span>
+                </div>
+                
+                {result.status === 'success' && result.data && (
+                  <div className="mt-3">
+                    <details className="cursor-pointer">
+                      <summary className="text-sm text-green-700 font-medium">
+                        レスポンスデータを表示 ({typeof result.data === 'object' ? 
+                          `${Object.keys(result.data).length} fields` : 
+                          typeof result.data})
+                      </summary>
+                      <pre className="mt-2 p-3 bg-green-100 rounded text-xs overflow-auto max-h-96">
+                        {JSON.stringify(result.data, null, 2)}
+                      </pre>
+                    </details>
+                  </div>
+                )}
+                
+                {result.status === 'error' && result.error && (
+                  <div className="mt-2">
+                    <p className="text-red-700 text-sm font-medium">
+                      エラー: {result.error}
+                    </p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {testResults.length === 0 && (
+            <div className="text-center py-8 text-gray-500">
+              「全テスト実行」ボタンを押して休眠顧客APIをテストしてください
+            </div>
+          )}
+        </div>
+      </div>
+      
+      {/* API情報 */}
+      <div className="mt-6 bg-gray-50 p-6 rounded-lg">
+        <h3 className="text-lg font-medium mb-3">🔗 API情報</h3>
+        <div className="text-sm text-gray-600 space-y-2">
+          <div><span className="font-medium">ベースURL:</span> https://shopifytestapi20250720173320-aed5bhc0cferg2hm.japanwest-01.azurewebsites.net</div>
+          <div><span className="font-medium">休眠顧客リスト:</span> GET /api/customer/dormant</div>
+          <div><span className="font-medium">サマリー統計:</span> GET /api/customer/dormant/summary</div>
+          <div><span className="font-medium">離脱確率:</span> GET /api/customer/{'{id}'}/churn-probability</div>
+          <div><span className="font-medium">実装:</span> Phase 1 - 基本機能実装済み</div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -16,6 +16,11 @@ export const API_CONFIG = {
     CUSTOMER_DETAILS: '/api/customer/details',
     CUSTOMER_DETAIL: '/api/customer/details', // + /{id}
     CUSTOMER_TOP: '/api/customer/top',
+    
+    // Dormant Customer API (休眠顧客分析API)
+    CUSTOMER_DORMANT: '/api/customer/dormant',
+    CUSTOMER_DORMANT_SUMMARY: '/api/customer/dormant/summary',
+    CUSTOMER_CHURN_PROBABILITY: '/api/customer', // + /{id}/churn-probability
   },
   
   // リクエスト設定
@@ -28,14 +33,39 @@ export const API_CONFIG = {
 
 // 環境別設定
 export const getApiUrl = () => {
-  // 開発環境の場合はローカルバックエンドも選択可能
-  if (process.env.NODE_ENV === 'development') {
-    return process.env.NEXT_PUBLIC_API_URL || API_CONFIG.BASE_URL;
+  // デバッグ情報の出力
+  console.log('🔍 Environment Check:');
+  console.log('  - NODE_ENV:', process.env.NODE_ENV);
+  console.log('  - NEXT_PUBLIC_API_URL:', process.env.NEXT_PUBLIC_API_URL);
+  console.log('  - NEXT_PUBLIC_DEBUG_API:', process.env.NEXT_PUBLIC_DEBUG_API);
+  
+  // 環境変数で明示的に設定されている場合はそれを優先
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    console.log('✅ Using NEXT_PUBLIC_API_URL:', process.env.NEXT_PUBLIC_API_URL);
+    return process.env.NEXT_PUBLIC_API_URL;
   }
+  
+  // デバッグモードが有効な場合はAzure App Serviceを使用
+  if (process.env.NEXT_PUBLIC_DEBUG_API === 'true') {
+    console.log('✅ Using Azure App Service URL (debug mode)');
+    return API_CONFIG.BASE_URL;
+  }
+  
+  // 開発環境の場合はAzure App Serviceを使用（ローカルバックエンドは未稼働のため）
+  if (process.env.NODE_ENV === 'development') {
+    console.log('✅ Using Azure App Service URL (development mode)');
+    return API_CONFIG.BASE_URL;
+  }
+  
+  // 本番環境
+  console.log('✅ Using production backend URL');
   return API_CONFIG.BASE_URL;
 };
 
 // フルURL生成ヘルパー
 export const buildApiUrl = (endpoint: string) => {
-  return `${getApiUrl()}${endpoint}`;
+  const baseUrl = getApiUrl();
+  const fullUrl = `${baseUrl}${endpoint}`;
+  console.log('🌐 Building API URL:', { baseUrl, endpoint, fullUrl });
+  return fullUrl;
 }; 

--- a/frontend/src/lib/menuConfig.backup-2025-07-24.ts
+++ b/frontend/src/lib/menuConfig.backup-2025-07-24.ts
@@ -1,0 +1,98 @@
+export interface MenuItem {
+  id: string
+  label: string
+  icon: string
+  href?: string  // Optional for parent items
+  category: "sales" | "purchase" | "customers" | "ai-insights"
+  isImplemented: boolean
+  description?: string
+  children?: MenuItem[]  // For submenu items
+}
+
+export const menuStructure: MenuItem[] = [
+  {
+    id: "sales-overview",
+    label: "売上ダッシュボード【概要】",
+    icon: "📊",
+    href: "/sales/dashboard",
+    category: "sales",
+    isImplemented: true,
+    description: "売上の全体像と主要KPIをリアルタイム確認"
+  },
+  {
+    id: "year-over-year",
+    label: "前年同月比較【商品別】",
+    icon: "📈",
+    href: "/sales/year-over-year",
+    category: "sales",
+    isImplemented: true,
+    description: "商品別の売上トレンドを前年と詳細比較"
+  },
+  {
+    id: "purchase-frequency",
+    label: "リピート購入分析【商品】",
+    icon: "🔄",
+    href: "/sales/purchase-frequency",
+    category: "sales",
+    isImplemented: true,
+    description: "商品別のリピート購入パターンと頻度分析"
+  },
+  {
+    id: "market-basket",
+    label: "バスケット分析【商品】",
+    icon: "🛒",
+    href: "/sales/market-basket",
+    category: "sales",
+    isImplemented: true,
+    description: "一緒に購入される商品の組み合わせとトレンド分析"
+  },
+  {
+    id: "monthly-stats",
+    label: "月次売上レポート【購買】",
+    icon: "📅",
+    href: "/sales/monthly-stats",
+    category: "purchase",
+    isImplemented: true,
+    description: "商品別×月別の売上推移を数量・金額で詳細把握"
+  },
+  {
+    id: "frequency-detail",
+    label: "購入回数セグメント【購買】",
+    icon: "🔢",
+    href: "/purchase/frequency-detail",
+    category: "purchase",
+    isImplemented: true,
+    description: "顧客の購入回数別セグメント分析と前年比較レポート"
+  },
+  {
+    id: "f-tier-trend",
+    label: "顧客階層トレンド【購買】",
+    icon: "📊",
+    href: "/purchase/f-tier-trend",
+    category: "purchase",
+    isImplemented: true,
+    description: "購入頻度による顧客階層の時系列変化とトレンド分析"
+  },
+  {
+    id: "customer-profile",
+    label: "顧客プロファイル【顧客】",
+    icon: "👤",
+    href: "/customers/profile",
+    category: "customers",
+    isImplemented: true,
+    description: "顧客別の詳細な購買履歴とプロファイル分析"
+  },
+  {
+    id: "dormant-customers",
+    label: "休眠顧客マネジメント【顧客】",
+    icon: "😴",
+    href: "/customers/dormant",
+    category: "customers",
+    isImplemented: true,
+    description: "最終購入からの経過期間別顧客分類と復帰施策管理"
+  },
+]
+
+export const getMenuByCategory = (category: string) => {
+  return menuStructure.filter(item => item.category === category)
+} 

--- a/frontend/src/lib/menuConfig.ts
+++ b/frontend/src/lib/menuConfig.ts
@@ -10,78 +10,79 @@ export interface MenuItem {
 }
 
 export const menuStructure: MenuItem[] = [
-  {
-    id: "sales-overview",
-    label: "売上ダッシュボード【概要】",
-    icon: "📊",
-    href: "/sales/dashboard",
-    category: "sales",
-    isImplemented: true,
-    description: "売上の全体像と主要KPIをリアルタイム確認"
-  },
-  {
-    id: "year-over-year",
-    label: "前年同月比較【商品別】",
-    icon: "📈",
-    href: "/sales/year-over-year",
-    category: "sales",
-    isImplemented: true,
-    description: "商品別の売上トレンドを前年と詳細比較"
-  },
-  {
-    id: "purchase-frequency",
-    label: "リピート購入分析【商品】",
-    icon: "🔄",
-    href: "/sales/purchase-frequency",
-    category: "sales",
-    isImplemented: true,
-    description: "商品別のリピート購入パターンと頻度分析"
-  },
-  {
-    id: "market-basket",
-    label: "バスケット分析【商品】",
-    icon: "🛒",
-    href: "/sales/market-basket",
-    category: "sales",
-    isImplemented: true,
-    description: "一緒に購入される商品の組み合わせとトレンド分析"
-  },
-  {
-    id: "monthly-stats",
-    label: "月次売上レポート【購買】",
-    icon: "📅",
-    href: "/sales/monthly-stats",
-    category: "purchase",
-    isImplemented: true,
-    description: "商品別×月別の売上推移を数量・金額で詳細把握"
-  },
-  {
-    id: "frequency-detail",
-    label: "購入回数セグメント【購買】",
-    icon: "🔢",
-    href: "/purchase/frequency-detail",
-    category: "purchase",
-    isImplemented: true,
-    description: "顧客の購入回数別セグメント分析と前年比較レポート"
-  },
-  {
-    id: "f-tier-trend",
-    label: "顧客階層トレンド【購買】",
-    icon: "📊",
-    href: "/purchase/f-tier-trend",
-    category: "purchase",
-    isImplemented: true,
-    description: "購入頻度による顧客階層の時系列変化とトレンド分析"
-  },
-  {
-    id: "customer-profile",
-    label: "顧客プロファイル【顧客】",
-    icon: "👤",
-    href: "/customers/profile",
-    category: "customers",
-    isImplemented: true,
-    description: "顧客別の詳細な購買履歴とプロファイル分析"
-  },
+  // 一時的に非表示 - 休眠顧客分析のみ表示
+  // {
+  //   id: "sales-overview",
+  //   label: "売上ダッシュボード【概要】",
+  //   icon: "📊",
+  //   href: "/sales/dashboard",
+  //   category: "sales",
+  //   isImplemented: true,
+  //   description: "売上の全体像と主要KPIをリアルタイム確認"
+  // },
+  // {
+  //   id: "year-over-year",
+  //   label: "前年同月比較【商品別】",
+  //   icon: "📈",
+  //   href: "/sales/year-over-year",
+  //   category: "sales",
+  //   isImplemented: true,
+  //   description: "商品別の売上トレンドを前年と詳細比較"
+  // },
+  // {
+  //   id: "purchase-frequency",
+  //   label: "リピート購入分析【商品】",
+  //   icon: "🔄",
+  //   href: "/sales/purchase-frequency",
+  //   category: "sales",
+  //   isImplemented: true,
+  //   description: "商品別のリピート購入パターンと頻度分析"
+  // },
+  // {
+  //   id: "market-basket",
+  //   label: "バスケット分析【商品】",
+  //   icon: "🛒",
+  //   href: "/sales/market-basket",
+  //   category: "sales",
+  //   isImplemented: true,
+  //   description: "一緒に購入される商品の組み合わせとトレンド分析"
+  // },
+  // {
+  //   id: "monthly-stats",
+  //   label: "月次売上レポート【購買】",
+  //   icon: "📅",
+  //   href: "/sales/monthly-stats",
+  //   category: "purchase",
+  //   isImplemented: true,
+  //   description: "商品別×月別の売上推移を数量・金額で詳細把握"
+  // },
+  // {
+  //   id: "frequency-detail",
+  //   label: "購入回数セグメント【購買】",
+  //   icon: "🔢",
+  //   href: "/purchase/frequency-detail",
+  //   category: "purchase",
+  //   isImplemented: true,
+  //   description: "顧客の購入回数別セグメント分析と前年比較レポート"
+  // },
+  // {
+  //   id: "f-tier-trend",
+  //   label: "顧客階層トレンド【購買】",
+  //   icon: "📊",
+  //   href: "/purchase/f-tier-trend",
+  //   category: "purchase",
+  //   isImplemented: true,
+  //   description: "購入頻度による顧客階層の時系列変化とトレンド分析"
+  // },
+  // {
+  //   id: "customer-profile",
+  //   label: "顧客プロファイル【顧客】",
+  //   icon: "👤",
+  //   href: "/customers/profile",
+  //   category: "customers",
+  //   isImplemented: true,
+  //   description: "顧客別の詳細な購買履歴とプロファイル分析"
+  // },
   {
     id: "dormant-customers",
     label: "休眠顧客マネジメント【顧客】",


### PR DESCRIPTION
## 主な変更内容

### フロントエンド
- **休眠顧客ページ**: モックデータから実際のAPI呼び出しに変更
  - `DormantCustomerAnalysis.tsx`: API統合実装
  - `customers/dormant/page.tsx`: API呼び出し機能追加
- **ルートページ**: デフォルトリダイレクト先を `/sales/dashboard` から `/dev-bookmarks` に変更
- **ナビゲーション**: 休眠顧客機能の実装状況を更新

### ドキュメント
- **BOOKMARKS.md**: 休眠顧客API関連リンクを追加
  - 本番環境とローカル環境のAPIエンドポイント
  - 休眠顧客APIテストページ
  - 休眠顧客サマリーAPI

### 技術的詳細
- API呼び出し時のエラーハンドリング強化
- ローディング状態とエラー状態の管理
- 休眠顧客データとサマリーデータの並行取得
- 開発環境でのデフォルトページ変更

## 影響範囲
- 休眠顧客分析機能の動作改善
- 開発効率向上（dev-bookmarksへの自動遷移）
- API統合によるデータの正確性向上